### PR TITLE
remove image population

### DIFF
--- a/src/server/routes/refs.js
+++ b/src/server/routes/refs.js
@@ -89,7 +89,7 @@ module.exports = (crowi) => {
         page: page._id,
         originalName: fileName,
       })
-      .populate({ path: 'creator', select: User.USER_PUBLIC_FIELDS, populate: User.IMAGE_POPULATION });
+      .populate({ path: 'creator', select: User.USER_PUBLIC_FIELDS });
 
     // not found
     if (attachment == null) {
@@ -183,7 +183,7 @@ module.exports = (crowi) => {
     }
 
     const attachments = await query
-      .populate({ path: 'creator', select: User.USER_PUBLIC_FIELDS, populate: User.IMAGE_POPULATION })
+      .populate({ path: 'creator', select: User.USER_PUBLIC_FIELDS })
       .exec();
 
     res.status(200).send({ attachments });


### PR DESCRIPTION
GROWI本体側のユーザー画像キャッシュ管理方法の変更に伴い IMAGE_POPULATIONが廃止されたのでその削除
（populationしたuser.imageAttachment の情報はこっちのソースコードでは利用されておらず、GROWI本体のPageAttachment/Attachment.jsx で使われているため、plugin側で画像表示部の改修の必要はない)
https://github.com/weseek/growi/blob/master/src/client/js/components/PageAttachment/Attachment.jsx#L59